### PR TITLE
Fix CLI config encoding and README command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ python -m nltk.downloader punkt   # cho baseline Punkt
 
 Sau khi chỉnh sửa đường dẫn dữ liệu trong `configs/default.yaml`, có thể chạy một baseline như sau:
 ```bash
-python -m senteg.cli -c configs/default.yaml --baseline regex
+python -m sentseg.cli -c configs/default.yaml --baseline regex
 ```
 
 Thay tham số `--baseline` bằng `crf`, `phobert`, `pysbd`, `punkt`, `wtp` hoặc `wtp_finetune` để thử nghiệm các phương pháp khác.

--- a/src/sentseg/cli.py
+++ b/src/sentseg/cli.py
@@ -36,7 +36,7 @@ def main():
                              "pysbd","punkt","wtp","wtp_finetune"],
                     default="regex")
     args = ap.parse_args()
-    cfg = yaml.safe_load(Path(args.config).read_text())
+    cfg = yaml.safe_load(Path(args.config).read_text(encoding="utf-8"))
 
     if args.baseline in ["crf", "phobert"]:
         ds.prepare(cfg)


### PR DESCRIPTION
## Summary
- ensure YAML config is read as UTF-8
- correct the README command

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_6856d582b018832f9964121f4cc0098a