### PR TITLE
Fix evaluation pos_label handling

### DIFF
--- a/src/sentseg/evaluator.py
+++ b/src/sentseg/evaluator.py
@@ -1,3 +1,5 @@
+"""Evaluation utilities for sentence segmentation baselines."""
+
 from sklearn.metrics import precision_recall_fscore_support, accuracy_score
 
 
@@ -14,10 +16,13 @@ def evaluate_labels(y_true, y_pred):
     y_pred_f = _flat(y_pred)
 
     labels = sorted(set(y_true_f) | set(y_pred_f))
-    if labels == ["B", "I"] or labels == ["I", "B"]:
+    if set(labels) == {"B", "I"}:
+        # Explicitly pass the label order to avoid ``pos_label`` errors on
+        # some scikit-learn versions which expect numerical labels by default.
         p, r, f, _ = precision_recall_fscore_support(
             y_true_f,
             y_pred_f,
+            labels=["B", "I"],
             average="binary",
             pos_label="B",
             zero_division=0,
@@ -26,6 +31,7 @@ def evaluate_labels(y_true, y_pred):
         p, r, f, _ = precision_recall_fscore_support(
             y_true_f,
             y_pred_f,
+            labels=labels,
             average="macro",
             zero_division=0,
         )


### PR DESCRIPTION
## Summary
- avoid sklearn pos_label errors by explicitly passing labels for 'B' and 'I'
- add module docstring to evaluator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857003d69e8832f8e37cda4d1d8cff4