### PR TITLE
Fix VIHSD labels and normalise dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SentenceSeg-VIHSD
 
-Bộ công cụ phân đoạn câu tiếng Việt trên tập **VIHSD** (gồm ba nhãn `clean=1`, `offensive=2`, `hate=3`) kèm 7 baseline:
+Bộ công cụ phân đoạn câu tiếng Việt trên tập **VIHSD** (các nhãn gốc `clean=0`, `offensive=1`, `hate=2`) kèm 7 baseline:
 
 | Baseline         | Nhóm        | Tham chiếu nghiên cứu         |
 |------------------|--------------|-----------------------------------------|


### PR DESCRIPTION
## Summary
- clarify original label numbering in README and dataset
- add `_remap_labels` helper to normalise any 1-indexed datasets
- use `_remap_labels` when loading CSVs

## Testing
- `python -m compileall -q src/sentseg/dataset.py`
- `python -m compileall -q src`


------
https://chatgpt.com/codex/tasks/task_e_685705769044832f9d0f724fbaf3d25d