### PR TITLE
Compute metrics for PhoBERT

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,8 @@ python -m sentseg.cli -c configs/default.yaml --baseline regex
 ```
 
 Thay tham số `--baseline` bằng `crf`, `phobert`, `pysbd`, `punkt`, `wtp` hoặc `wtp_finetune` để thử nghiệm các phương pháp khác. Lệnh sẽ in ra F1 và Accuracy của mô hình trên tập dev và test.
+
+### Lưu ý
+
+- Baseline `phobert` yêu cầu `transformers>=4.41.0`. Nếu cài phiên bản cũ hơn, lệnh có thể báo lỗi `TypeError` ở tham số `evaluation_strategy`.
+- Khi dùng `phobert`, chương trình sẽ in F1 và Accuracy trên tập dev và test sau khi huấn luyện.

--- a/src/sentseg/cli.py
+++ b/src/sentseg/cli.py
@@ -8,6 +8,7 @@ from sentseg.baselines import (
     punkt_wrapper,
     wtp_wrapper,
 )
+from sentseg.models.transformer import PhoBERTSegmenter
 
 def run_baseline(baseline, cfg):
     _, dev_df, test_df = ds.load(cfg)
@@ -63,6 +64,11 @@ def main():
             print(f"Test F1={test_res['f1']:.4f} Acc={test_res['accuracy']:.4f}")
         else:
             trainer.train_transformer(cfg)
+            segmenter = PhoBERTSegmenter(model_name=cfg["output"]["dir"])
+            dev_res = evaluator.evaluate_split(segmenter.predict, dev_df)
+            test_res = evaluator.evaluate_split(segmenter.predict, test_df)
+            print(f"Dev F1={dev_res['f1']:.4f} Acc={dev_res['accuracy']:.4f}")
+            print(f"Test F1={test_res['f1']:.4f} Acc={test_res['accuracy']:.4f}")
     else:
         run_baseline(args.baseline, cfg)
 

--- a/src/sentseg/trainer.py
+++ b/src/sentseg/trainer.py
@@ -2,8 +2,14 @@ from pathlib import Path
 from typing import Dict
 import pandas as pd
 from datasets import Dataset
-from transformers import (AutoTokenizer, AutoModelForTokenClassification,
-                          Trainer, TrainingArguments)
+from transformers import (
+    AutoTokenizer,
+    AutoModelForTokenClassification,
+    Trainer,
+    TrainingArguments,
+)
+from packaging import version
+import transformers
 from sentseg.models import crf_model
 from sentseg.features import sent2features, sent2labels
 
@@ -33,6 +39,10 @@ def train_crf(cfg: Dict):
 
 # ------------ PhoBERT ---------------
 def train_transformer(cfg: Dict):
+    if version.parse(transformers.__version__) < version.parse("4.41.0"):
+        raise RuntimeError(
+            f"transformers >=4.41.0 required, found {transformers.__version__}"
+        )
     tk = AutoTokenizer.from_pretrained(cfg["models"]["transformer"]["model_name"])
 
     def _encode(batch):


### PR DESCRIPTION
## Summary
- remove note about missing metrics in PhoBERT docs
- evaluate dev/test after training PhoBERT

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6857167dabbc832f82c5714e9adb21c2