### PR TITLE
Implement classification pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,11 @@ Thay tham số `--baseline` bằng `crf`, `phobert`, `pysbd`, `punkt`, `wtp` ho�
 
 - Baseline `phobert` yêu cầu `transformers>=4.41.0`. Nếu cài phiên bản cũ hơn, lệnh có thể báo lỗi `TypeError` ở tham số `evaluation_strategy`.
 - Khi dùng `phobert`, chương trình sẽ in F1 và Accuracy trên tập dev và test sau khi huấn luyện.
+
+## Phân loại văn bản
+
+Pipeline phân loại dựa trên các bước: câu -> tách câu (theo baseline) -> mô hình (TextCNN, BERT, GRU). Có thể chạy như sau:
+```bash
+python -m sentseg.classify_cli -c configs/default.yaml --baseline regex --model textcnn
+```
+Thay `--model` bằng `bert` hoặc `gru` để thử nghiệm các mô hình khác. Kết quả sẽ in ra F1 và Accuracy trên tập dev và test.

--- a/src/sentseg/classifier_models.py
+++ b/src/sentseg/classifier_models.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+import importlib
+from typing import Iterable, Tuple
+
+
+def _load_torch():
+    try:
+        torch = importlib.import_module("torch")
+        nn = importlib.import_module("torch.nn")
+        F = importlib.import_module("torch.nn.functional")
+        return torch, nn, F
+    except Exception as e:
+        raise ImportError("PyTorch is required for this module") from e
+
+
+def build_textcnn(vocab_size: int, num_classes: int, embed_dim: int = 128,
+                  kernel_sizes: Iterable[int] = (3, 4, 5), num_filters: int = 100,
+                  dropout: float = 0.5):
+    torch, nn, F = _load_torch()
+
+    class TextCNN(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embedding = nn.Embedding(vocab_size, embed_dim)
+            self.convs = nn.ModuleList([
+                nn.Conv1d(embed_dim, num_filters, k) for k in kernel_sizes
+            ])
+            self.dropout = nn.Dropout(dropout)
+            self.fc = nn.Linear(num_filters * len(kernel_sizes), num_classes)
+
+        def forward(self, x):
+            x = self.embedding(x).permute(0, 2, 1)
+            conved = [F.relu(c(x)).max(dim=2)[0] for c in self.convs]
+            out = torch.cat(conved, dim=1)
+            out = self.dropout(out)
+            return self.fc(out)
+
+    return TextCNN()
+
+
+def build_gru(vocab_size: int, num_classes: int, embed_dim: int = 128,
+              hidden_dim: int = 128, num_layers: int = 1,
+              bidirectional: bool = True, dropout: float = 0.5):
+    torch, nn, F = _load_torch()
+
+    class GRUClassifier(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embedding = nn.Embedding(vocab_size, embed_dim)
+            self.rnn = nn.GRU(embed_dim, hidden_dim, num_layers,
+                              batch_first=True, bidirectional=bidirectional,
+                              dropout=dropout if num_layers > 1 else 0)
+            direc = 2 if bidirectional else 1
+            self.fc = nn.Linear(hidden_dim * direc, num_classes)
+            self.dropout = nn.Dropout(dropout)
+
+        def forward(self, x):
+            x = self.dropout(self.embedding(x))
+            _, h = self.rnn(x)
+            if bidirectional:
+                h = torch.cat([h[-2], h[-1]], dim=1)
+            else:
+                h = h[-1]
+            return self.fc(h)
+
+    return GRUClassifier()
+
+
+def build_bert(model_name: str = "bert-base-uncased", num_classes: int = 3):
+    torch, nn, _ = _load_torch()
+    transformers = importlib.import_module("transformers")
+    model = transformers.AutoModelForSequenceClassification.from_pretrained(
+        model_name, num_labels=num_classes
+    )
+    tokenizer = transformers.AutoTokenizer.from_pretrained(model_name)
+    return model, tokenizer

--- a/src/sentseg/classify_cli.py
+++ b/src/sentseg/classify_cli.py
@@ -1,0 +1,106 @@
+import argparse
+import yaml
+from pathlib import Path
+from typing import Callable
+from sentseg import dataset as ds, evaluator
+from sentseg.baseline import split as regex_split
+from sentseg.baselines import pysbd_wrapper, punkt_wrapper, wtp_wrapper
+from sentseg.classifier_models import build_textcnn, build_gru, build_bert
+
+
+def apply_segmentation(df, split_func: Callable[[str], list[str]]):
+    df = df.copy()
+    df["segmented"] = df["free_text"].apply(lambda t: " ".join(split_func(str(t))))
+    return df
+
+
+def load_baseline(name: str) -> Callable[[str], list[str]]:
+    if name == "regex":
+        return regex_split
+    if name == "pysbd":
+        return pysbd_wrapper.PySBDSplitter().split
+    if name == "punkt":
+        return punkt_wrapper.PunktSplitter().split
+    if name == "wtp":
+        return wtp_wrapper.WtPSplitter().split
+    raise ValueError("unknown baseline")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("-c", "--config", required=True)
+    ap.add_argument("--baseline", default="regex",
+                    choices=["regex", "pysbd", "punkt", "wtp"])
+    ap.add_argument("--model", default="textcnn",
+                    choices=["textcnn", "bert", "gru"])
+    args = ap.parse_args()
+
+    cfg = yaml.safe_load(Path(args.config).read_text(encoding="utf-8"))
+    splitter = load_baseline(args.baseline)
+
+    train_df, dev_df, test_df = ds.load(cfg)
+    train_df = apply_segmentation(train_df, splitter)
+    dev_df = apply_segmentation(dev_df, splitter)
+    test_df = apply_segmentation(test_df, splitter)
+
+    if args.model == "bert":
+        model, tk = build_bert(num_classes=3)
+        enc = lambda batch: tk(batch["segmented"], truncation=True, padding=True)
+    else:
+        tk = lambda x: x.split()
+        # Build vocabulary
+        vocab = {tok for text in train_df["segmented"] for tok in tk(text)}
+        stoi = {tok: i + 2 for i, tok in enumerate(sorted(vocab))}
+        stoi["<pad>"] = 0
+        stoi["<unk>"] = 1
+
+        def encode(text):
+            return [stoi.get(tok, 1) for tok in tk(text)]
+
+        enc = lambda batch: {"input_ids": [encode(t) for t in batch["segmented"]]}
+        if args.model == "textcnn":
+            model = build_textcnn(len(stoi), 3)
+        else:
+            model = build_gru(len(stoi), 3)
+
+    train_ds = {**enc(train_df), "labels": train_df["label"].tolist()}
+    dev_ds = {**enc(dev_df), "labels": dev_df["label"].tolist()}
+    test_ds = {**enc(test_df), "labels": test_df["label"].tolist()}
+
+    # Simple training loop (placeholder)
+    try:
+        torch, nn, F = __import__("importlib").import_module("torch"), \
+            __import__("importlib").import_module("torch.nn"), \
+            __import__("importlib").import_module("torch.nn.functional")
+    except Exception:
+        raise ImportError("PyTorch required to train models")
+
+    optim = torch.optim.Adam(model.parameters(), lr=1e-3)
+    loss_fn = nn.CrossEntropyLoss()
+    X = torch.tensor(train_ds["input_ids"], dtype=torch.long)
+    y = torch.tensor(train_ds["labels"], dtype=torch.long)
+    model.train()
+    for _ in range(2):  # few epochs for demo
+        optim.zero_grad()
+        out = model(X)
+        loss = loss_fn(out, y)
+        loss.backward()
+        optim.step()
+
+    def predict(dataset):
+        model.eval()
+        X = torch.tensor(dataset["input_ids"], dtype=torch.long)
+        with torch.no_grad():
+            out = model(X).argmax(-1).tolist()
+        return out
+
+    dev_pred = predict(dev_ds)
+    test_pred = predict(test_ds)
+    dev_res = evaluator.evaluate_labels(dev_ds["labels"], dev_pred)
+    test_res = evaluator.evaluate_labels(test_ds["labels"], test_pred)
+    print(f"Dev F1={dev_res['f1']:.4f} Acc={dev_res['accuracy']:.4f}")
+    print(f"Test F1={test_res['f1']:.4f} Acc={test_res['accuracy']:.4f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple TextCNN/GRU/BERT model definitions
- implement `classify_cli.py` for segmentation + classification
- document usage of the new classification pipeline

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68572ea3a1f8832fa10081c0c9cbe65c