### PR TITLE
Add FastText pretraining and multilingual BERT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,5 +17,6 @@ dependencies = [
   "wtpsplit>=0.2.0",
   "pyyaml>=6.0",
   "nltk>=3.8.1",
-  "tqdm"
+  "tqdm",
+  "gensim>=4.3.2"
 ]


### PR DESCRIPTION
## Summary
- support FastText embeddings for TextCNN/GRU models
- default to `bert-base-multilingual-cased` when building BERT models
- add optional `--fasttext` argument in CLI
- depend on gensim for loading vectors

## Testing
- `pip install -e .`
- `python -m nltk.downloader punkt`


------
https://chatgpt.com/codex/tasks/task_e_685744a0a604832f93bab2793d6b01e3