### PR TITLE
Improve dataset loading error and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SentenceSeg-VIHSD
 
-Bộ công cụ phân đoạn câu tiếng Việt trên tập **VIHSD** (gồm ba nhãn `clean=1`, `offensive=2`, `hate=3`) kèm 6 baseline:
+Bộ công cụ phân đoạn câu tiếng Việt trên tập **VIHSD** (gồm ba nhãn `clean=0`, `offensive=1`, `hate=2`) kèm 6 baseline:
 
 | Baseline         | Nhóm        | Tham chiếu nghiên cứu         |
 |------------------|--------------|-----------------------------------------|

--- a/src/sentseg/dataset.py
+++ b/src/sentseg/dataset.py
@@ -39,10 +39,18 @@ def _remap_labels(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+def _read_csv(path: str) -> pd.DataFrame:
+    """Read a CSV file with a clearer error message if it is missing."""
+    f = Path(path)
+    if not f.exists():
+        raise FileNotFoundError(f"Dataset file not found: {path}")
+    return pd.read_csv(f)
+
+
 def load(cfg: Dict) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-    train = pd.read_csv(cfg["data"]["train_path"])
-    dev = pd.read_csv(cfg["data"]["dev_path"])
-    test = pd.read_csv(cfg["data"]["test_path"])
+    train = _read_csv(cfg["data"]["train_path"])
+    dev = _read_csv(cfg["data"]["dev_path"])
+    test = _read_csv(cfg["data"]["test_path"])
     return (_remap_labels(train), _remap_labels(dev), _remap_labels(test))
 
 def _split_row(row) -> List[str]:


### PR DESCRIPTION
## Summary
- clarify label mapping in README
- improve dataset loader to check file existence
- ignore egg-info build output

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m sentseg.cli -c configs/default.yaml --baseline regex --model textcnn > /tmp/run.log 2>&1` *(fails: Dataset file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594c8d526c832f8604b9ef81e6510b