### PR TITLE
Prefer GPU when available

### DIFF
--- a/src/sentseg/classify_cli.py
+++ b/src/sentseg/classify_cli.py
@@ -80,10 +80,13 @@ def main():
     except Exception:
         raise ImportError("PyTorch required to train models")
 
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+
     optim = torch.optim.Adam(model.parameters(), lr=1e-3)
     loss_fn = nn.CrossEntropyLoss()
-    X = torch.tensor(train_ds["input_ids"], dtype=torch.long)
-    y = torch.tensor(train_ds["labels"], dtype=torch.long)
+    X = torch.tensor(train_ds["input_ids"], dtype=torch.long).to(device)
+    y = torch.tensor(train_ds["labels"], dtype=torch.long).to(device)
     model.train()
     for _ in range(2):  # few epochs for demo
         optim.zero_grad()
@@ -94,9 +97,9 @@ def main():
 
     def predict(dataset):
         model.eval()
-        X = torch.tensor(dataset["input_ids"], dtype=torch.long)
+        X = torch.tensor(dataset["input_ids"], dtype=torch.long).to(device)
         with torch.no_grad():
-            out = model(X).argmax(-1).tolist()
+            out = model(X).argmax(-1).cpu().tolist()
         return out
 
     dev_pred = predict(dev_ds)

--- a/src/sentseg/cli.py
+++ b/src/sentseg/cli.py
@@ -84,6 +84,7 @@ def main():
         import importlib
         torch = importlib.import_module("torch")
         nn = importlib.import_module("torch.nn")
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     except Exception:
         use_torch = False
 
@@ -142,8 +143,9 @@ def main():
         # ─── 5. Huấn luyện demo (2 epoch) ───────────────────────────────────
         optim = torch.optim.Adam(model.parameters(), lr=1e-3)
         loss_fn = nn.CrossEntropyLoss()
-        X = torch.tensor(train_ds["input_ids"], dtype=torch.long)
-        y = torch.tensor(train_ds["labels"],     dtype=torch.long)
+        X = torch.tensor(train_ds["input_ids"], dtype=torch.long).to(device)
+        y = torch.tensor(train_ds["labels"],     dtype=torch.long).to(device)
+        model.to(device)
 
         model.train()
         for _ in range(2):
@@ -156,9 +158,9 @@ def main():
         # ─── 6. Dự đoán & đánh giá ─────────────────────────────────────────
         def predict(dataset):
             model.eval()
-            X = torch.tensor(dataset["input_ids"], dtype=torch.long)
+            X = torch.tensor(dataset["input_ids"], dtype=torch.long).to(device)
             with torch.no_grad():
-                return model(X).argmax(-1).tolist()
+                return model(X).argmax(-1).cpu().tolist()
 
         dev_pred  = predict(dev_ds)
         test_pred = predict(test_ds)
@@ -185,8 +187,9 @@ def main():
 
         optim = torch.optim.Adam(model.parameters(), lr=1e-3)
         loss_fn = nn.CrossEntropyLoss()
-        X = torch.tensor(train_ds["input_ids"], dtype=torch.long)
-        y = torch.tensor(train_ds["labels"],     dtype=torch.long)
+        X = torch.tensor(train_ds["input_ids"], dtype=torch.long).to(device)
+        y = torch.tensor(train_ds["labels"],     dtype=torch.long).to(device)
+        model.to(device)
 
         model.train()
         for _ in range(2):
@@ -198,9 +201,9 @@ def main():
 
         def predict(dataset):
             model.eval()
-            X = torch.tensor(dataset["input_ids"], dtype=torch.long)
+            X = torch.tensor(dataset["input_ids"], dtype=torch.long).to(device)
             with torch.no_grad():
-                return model(X).argmax(-1).tolist()
+                return model(X).argmax(-1).cpu().tolist()
 
         dev_pred  = predict(dev_ds)
         test_pred = predict(test_ds)


### PR DESCRIPTION
## Summary
- choose CUDA device if available for classifier CLI
- select GPU in main CLI for training and prediction
- move transformer model and tensors to GPU when available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685983c59810832fa16d758d22667b42