### PR TITLE
Fix WtP baseline model

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Thay `--baseline` bằng `none`, `punkt` hoặc `wtp` và `--model` bằng `bert
 
 - Baseline `phobert` yêu cầu `transformers>=4.41.0`. Nếu cài phiên bản cũ hơn, lệnh có thể báo lỗi `TypeError` ở tham số `evaluation_strategy`.
 - Khi dùng `phobert`, chương trình sẽ in F1 và Accuracy trên tập dev và test sau khi huấn luyện.
+- Baseline `wtp` mặc định tải mô hình `wtp-bert-mini` từ HuggingFace. Hãy đảm
+  bảo máy tính có kết nối mạng trong lần chạy đầu tiên.
 
 ## Phân loại văn bản
 

--- a/src/sentseg/baselines/wtp_wrapper.py
+++ b/src/sentseg/baselines/wtp_wrapper.py
@@ -2,7 +2,14 @@ from wtpsplit import WtP
 
 
 class WtPSplitter:
-    def __init__(self, model: str = "wtp-xlmr-c3"):
+    def __init__(self, model: str = "wtp-bert-mini"):
+        """Wrapper around :class:`wtpsplit.WtP` with a sane default model.
+
+        The previously used ``wtp-xlmr-c3`` model has been removed from
+        HuggingFace, causing downloads to fail.  ``wtp-bert-mini`` is still
+        available and lightweight enough for most use cases, so we adopt it as
+        the new default.
+        """
         self.wtp = WtP(model)
 
     def split(self, text: str, lang: str = "vi"):


### PR DESCRIPTION
## Summary
- update default WtP model to `wtp-bert-mini`
- clarify in the README how the `wtp` baseline downloads this model

## Testing
- `python -m py_compile src/sentseg/baselines/wtp_wrapper.py`
- `python -m py_compile src/sentseg/cli.py src/sentseg/classify_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68598c05bb74832f886ca72b69da5fb3