### PR TITLE
Fix BERT loss tensor

### DIFF
--- a/src/sentseg/cli.py
+++ b/src/sentseg/cli.py
@@ -172,7 +172,7 @@ def main():
                 Xb, yb = Xb.to(device), yb.to(device)
                 optim.zero_grad()
                 out = model(Xb)
-                loss = loss_fn(out, yb)
+                loss = loss_fn(out.logits, yb)
                 loss.backward()
                 optim.step()
 
@@ -184,7 +184,7 @@ def main():
             preds = []
             with torch.no_grad():
                 for Xb in loader:
-                    out = model(Xb.to(device)).argmax(-1).cpu().tolist()
+                    out = model(Xb.to(device)).logits.argmax(-1).cpu().tolist()
                     preds.extend(out)
             return preds
 


### PR DESCRIPTION
## Summary
- fix cross entropy call in BERT training loop
- use logits when predicting with BERT models

## Testing
- `pip install numpy`
- `pip install torch transformers datasets` *(fails: ModuleNotFoundError during CLI run)*

------
https://chatgpt.com/codex/tasks/task_e_6859a98a64c4832fa0034f9edd2c6c96