### PR TITLE
Implement CRF baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Sau khi chỉnh sửa đường dẫn dữ liệu trong `configs/default.yaml`, 
 python -m sentseg.cli -c configs/default.yaml --baseline regex --model textcnn
 ```
 
-Thay `--baseline` bằng `none`, `punkt` hoặc `wtp` và `--model` bằng `bert` hoặc `gru` tùy nhu cầu. Lệnh sẽ in ra F1 và Accuracy trên tập dev và test.
+Thay `--baseline` bằng `none`, `punkt`, `wtp`, `crf` hoặc `phobert` và `--model` bằng `bert` hoặc `gru` tùy nhu cầu. Lệnh sẽ in ra F1 và Accuracy trên tập dev và test.
 
 ### Lưu ý
 

--- a/src/sentseg/baselines/crf_wrapper.py
+++ b/src/sentseg/baselines/crf_wrapper.py
@@ -1,0 +1,26 @@
+import pickle
+from pathlib import Path
+from sentseg.dataset import _sent2tokens
+from sentseg.features import sent2features
+
+class CRFSplitter:
+    """Sentence splitter using a pre‑trained CRF model."""
+    def __init__(self, model_path: str | Path):
+        path = Path(model_path)
+        self.model = pickle.loads(path.read_bytes())
+
+    def split(self, text: str):
+        tokens = _sent2tokens(text)
+        if not tokens:
+            return []
+        feats = sent2features([(tok, "I") for tok in tokens])
+        labels = self.model.predict([feats])[0]
+        sents, buf = [], []
+        for tok, lab in zip(tokens, labels):
+            buf.append(tok)
+            if lab == "B":
+                sents.append(" ".join(buf))
+                buf = []
+        if buf:
+            sents.append(" ".join(buf))
+        return sents


### PR DESCRIPTION
## Summary
- add CRF baseline splitter module
- support CRF baseline in CLIs
- document CRF usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859b45d3ff0832f9845c68b341e9038