### PR TITLE
Add automatic CRF training

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Thay `--baseline` bằng `none`, `punkt`, `wtp`, `crf` hoặc `phobert` và `--m
 - Khi dùng `phobert`, chương trình sẽ in F1 và Accuracy trên tập dev và test sau khi huấn luyện.
 - Baseline `wtp` mặc định tải mô hình `wtp-bert-mini` từ HuggingFace. Hãy đảm
   bảo máy tính có kết nối mạng trong lần chạy đầu tiên.
+- Baseline `crf` sẽ tự động huấn luyện và lưu `crf.pkl` vào thư mục `output.dir`
+  nếu chưa tồn tại.
 
 ## Phân loại văn bản
 

--- a/src/sentseg/classify_cli.py
+++ b/src/sentseg/classify_cli.py
@@ -25,8 +25,12 @@ def load_baseline(name: str, cfg: dict | None = None) -> Callable[[str], list[st
     if name == "crf":
         from sentseg.baselines import crf_wrapper
         from pathlib import Path
+        from sentseg import dataset, trainer
         model_dir = Path(cfg.get("output", {}).get("dir", ".")) if cfg else Path(".")
         model_path = model_dir / "crf.pkl"
+        if cfg is not None and not model_path.exists():
+            dataset.prepare(cfg)
+            trainer.train_crf(cfg)
         return crf_wrapper.CRFSplitter(model_path).split
     if name == "wtp":
         try:

--- a/src/sentseg/cli.py
+++ b/src/sentseg/cli.py
@@ -37,8 +37,12 @@ def load_baseline(name: str, cfg: dict | None = None) -> Callable[[str], List[st
         return punkt_wrapper.PunktSplitter().split
     if name == "crf":
         from sentseg.baselines import crf_wrapper
+        from sentseg import dataset, trainer
         model_dir = Path(cfg.get("output", {}).get("dir", ".")) if cfg else Path(".")
         model_path = model_dir / "crf.pkl"
+        if cfg is not None and not model_path.exists():
+            dataset.prepare(cfg)
+            trainer.train_crf(cfg)
         return crf_wrapper.CRFSplitter(model_path).split
     if name == "wtp":
         try:


### PR DESCRIPTION
## Summary
- automatically train and save CRF model when using the CRF baseline
- update README with new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b9d714dc832fb29e7e901f7afa67