### PR TITLE
Generalise dataset loader for multiple datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,17 @@ python -m sentseg.cli -c configs/default.yaml --baseline regex --model textcnn
 
 Thay `--baseline` bằng `none`, `punkt`, `wtp`, `crf` và `--model` bằng `bert` hoặc `gru` tùy nhu cầu. Lệnh sẽ in ra F1 và Accuracy trên tập dev và test.
 
+Nếu muốn thử nghiệm trên bộ dữ liệu nhận dạng spam, chỉnh sửa đường dẫn trong
+`configs/spam.yaml` (hoặc truyền file cấu hình tương tự) rồi chạy:
+
+```bash
+python -m sentseg.cli -c configs/spam.yaml --baseline regex --model textcnn
+```
+
+Hai file cấu hình `default.yaml` và `spam.yaml` có chung định dạng và chỉ khác ở
+đường dẫn dữ liệu cũng như tên cột chứa nội dung (`text_column`) và nhãn
+(`label_column`). Nhờ đó có thể chuyển đổi linh hoạt giữa các tập dữ liệu khi
+thực hiện các thí nghiệm.
+
 
 

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -2,6 +2,8 @@ data:
   train_path: data/train.csv   # sửa lại path thực
   dev_path:   data/dev.csv
   test_path:  data/test.csv
+  text_column: free_text
+  label_column: label_id
   train_conll: data/train.conll
 
 models:

--- a/configs/spam.yaml
+++ b/configs/spam.yaml
@@ -1,0 +1,23 @@
+data:
+  train_path: spamdata/train.csv
+  dev_path: spamdata/dev.csv
+  test_path: spamdata/test.csv
+  text_column: comment
+  label_column: spam_label
+  train_conll: spamdata/train.conll
+
+models:
+  crf:
+    c1: 0.1
+    c2: 0.1
+    max_iter: 200
+  transformer:
+    model_name: vinai/phobert-base
+
+trainer:
+  batch_size: 16
+  learning_rate: 5e-5
+  epochs: 3
+
+output:
+  dir: /mnt/data/sentseg_output


### PR DESCRIPTION
## Summary
- generalise dataset loader to rename configurable columns
- add new configuration for spam dataset
- document how to switch datasets

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877cb46911c83289c9485d0b943753d