### PR TITLE
Add task switch for spam dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ Nếu muốn thử nghiệm trên bộ dữ liệu nhận dạng spam, chỉnh s
 python -m sentseg.cli -c configs/spam.yaml --baseline regex --model textcnn
 ```
 
+Tuỳ chọn `--task` cho phép chuyển đổi giữa hai bài toán:
+
+```bash
+# Task 1: phát hiện spam hay không spam
+python -m sentseg.cli -c configs/spam.yaml --model textcnn --task 1
+# Task 2: phân loại các kiểu spam (SPAM-1, SPAM-2, SPAM-3)
+python -m sentseg.cli -c configs/spam.yaml --model textcnn --task 2
+```
+
 Hai file cấu hình `default.yaml` và `spam.yaml` có chung định dạng và chỉ khác ở
 đường dẫn dữ liệu cũng như tên cột chứa nội dung (`text_column`) và nhãn
 (`label_column`). Nhờ đó có thể chuyển đổi linh hoạt giữa các tập dữ liệu khi

--- a/src/sentseg/cli.py
+++ b/src/sentseg/cli.py
@@ -70,10 +70,20 @@ def main():
     ap.add_argument("--baseline", default="regex", choices=["regex", "none", "punkt", "wtp", "crf"])
     ap.add_argument("--model", required=True, choices=["textcnn", "bert", "gru"], help="classification model")
     ap.add_argument("--fasttext", help="Path to FastText .vec embeddings")
+    ap.add_argument(
+        "--task",
+        type=int,
+        choices=[1, 2],
+        default=1,
+        help="1=spam/not spam, 2=spam type classification",
+    )
     args = ap.parse_args()
 
     # ─── 2. Load dữ liệu & tiền xử lý ───────────────────────────────────────
     cfg = yaml.safe_load(Path(args.config).read_text(encoding="utf-8"))
+    if "data" not in cfg:
+        cfg["data"] = {}
+    cfg["data"]["label_column"] = "label" if args.task == 1 else "spam_label"
     splitter = load_baseline(args.baseline, cfg)
 
     train_df, dev_df, test_df = ds.load(cfg)


### PR DESCRIPTION
## Summary
- add `--task` option to select spam detection task
- allow CLI to choose label column based on task
- document task switch usage in README

## Testing
- `python -m py_compile src/sentseg/cli.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687900cdf3b0832893029e32f804ea2f