### PR TITLE
Enable spam tasks without torch

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Tuỳ chọn `--task` cho phép chuyển đổi giữa hai bài toán:
 
 ```bash
 # Task 1: phát hiện spam hay không spam
-python -m sentseg.cli -c configs/spam.yaml --model textcnn --task 1
+python -m sentseg.cli -c configs/spam.yaml --baseline regex --model textcnn --task 1
 # Task 2: phân loại các kiểu spam (SPAM-1, SPAM-2, SPAM-3)
-python -m sentseg.cli -c configs/spam.yaml --model textcnn --task 2
+python -m sentseg.cli -c configs/spam.yaml --baseline regex --model textcnn --task 2
 ```
 
 Hai file cấu hình `default.yaml` và `spam.yaml` có chung định dạng và chỉ khác ở

--- a/src/sentseg/cli.py
+++ b/src/sentseg/cli.py
@@ -9,7 +9,9 @@ import yaml
 import numpy as np
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.linear_model import LogisticRegression
-from torch.utils.data import DataLoader, TensorDataset
+
+# These are only available when PyTorch is installed
+DataLoader = TensorDataset = None
 
 from sentseg import dataset as ds, evaluator
 from sentseg.baseline import split as regex_split
@@ -102,6 +104,8 @@ def main():
         import importlib
         torch = importlib.import_module("torch")
         nn = importlib.import_module("torch.nn")
+        global DataLoader, TensorDataset
+        from torch.utils.data import DataLoader, TensorDataset
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     except Exception:
         use_torch = False


### PR DESCRIPTION
## Summary
- allow running CLI when PyTorch is absent
- document `--task` usage in README

## Testing
- `PYTHONPATH=src python -m sentseg.cli -c configs/spam.yaml --baseline regex --model textcnn --task 1`
- `PYTHONPATH=src python -m sentseg.cli -c configs/spam.yaml --baseline regex --model textcnn --task 2`


------
https://chatgpt.com/codex/tasks/task_e_68791f603de483288ef9c8317c9d28dd