### PR TITLE
Remove extraneous comments

### DIFF
--- a/src/sentseg/baselines/regex.py
+++ b/src/sentseg/baselines/regex.py
@@ -1,1 +1,1 @@
-from sentseg.baseline import split  # alias
+from sentseg.baseline import split

--- a/src/sentseg/classify_cli.py
+++ b/src/sentseg/classify_cli.py
@@ -7,7 +7,6 @@ from sentseg.baseline import split as regex_split
 from sentseg.baselines import punkt_wrapper, wtp_wrapper
 from sentseg.classifier_models import build_textcnn, build_gru, build_bert
 
-
 def apply_segmentation(df, split_func: Callable[[str], list[str]]):
     df = df.copy()
     df["segmented"] = df["free_text"].apply(lambda t: " ".join(split_func(str(t))))
@@ -63,7 +62,6 @@ def main():
         enc = lambda batch: tk(batch["segmented"], truncation=True, padding=True)
     else:
         tk = lambda x: x.split()
-        # Build vocabulary
         vocab = {tok for text in train_df["segmented"] for tok in tk(text)}
         stoi = {tok: i + 2 for i, tok in enumerate(sorted(vocab))}
         stoi["<pad>"] = 0
@@ -82,7 +80,6 @@ def main():
     dev_ds = {**enc(dev_df), "labels": dev_df["label"].tolist()}
     test_ds = {**enc(test_df), "labels": test_df["label"].tolist()}
 
-    # Simple training loop (placeholder)
     try:
         torch, nn, F = __import__("importlib").import_module("torch"), \
             __import__("importlib").import_module("torch.nn"), \
@@ -98,7 +95,7 @@ def main():
     X = torch.tensor(train_ds["input_ids"], dtype=torch.long).to(device)
     y = torch.tensor(train_ds["labels"], dtype=torch.long).to(device)
     model.train()
-    for _ in range(2):  # few epochs for demo
+    for _ in range(2):
         optim.zero_grad()
         out = model(X)
         loss = loss_fn(out, y)

--- a/src/sentseg/dataset.py
+++ b/src/sentseg/dataset.py
@@ -21,7 +21,6 @@ These labels are not used for sentence segmentation but remain in the CSV
 files for reference.
 """
 
-# ---------- tiny helpers ----------
 def _split_by_punc(text: str) -> List[str]:
     return [p for p in re.split(r"(?<=[.!?])\s+", text.strip()) if p]
 
@@ -29,7 +28,6 @@ def _sent2tokens(sent: str) -> List[str]:
     sent = re.sub(r"([.!?])", r" \1 ", sent)
     return sent.split()
 
-# ---------- public API ------------
 def _remap_labels(df: pd.DataFrame, col: str) -> pd.DataFrame:
     """Ensure class labels are 0-indexed (clean=0, offensive=1, hate=2).
 
@@ -46,7 +44,7 @@ def _remap_labels(df: pd.DataFrame, col: str) -> pd.DataFrame:
 
     df = df.copy()
     vals = set(df[col].unique())
-    if vals <= {1, 2, 3}:  # dataset uses 1-based indexing
+    if vals <= {1, 2, 3}:
         df[col] = df[col].map({1: 0, 2: 1, 3: 2})
     return df
 
@@ -100,7 +98,7 @@ def make_conll(df: pd.DataFrame, out_path: Path) -> None:
             for i, tok in enumerate(toks):
                 lab = "B" if i == len(toks) - 1 else "I"
                 rows.append(f"{tok}\t{lab}")
-            rows.append("")          # blank line = new sentence
+            rows.append("")
     out_path.write_text("\n".join(rows), encoding="utf-8")
 
 def prepare(cfg: Dict):

--- a/src/sentseg/trainer.py
+++ b/src/sentseg/trainer.py
@@ -13,7 +13,6 @@ import transformers
 from sentseg.models import crf_model
 from sentseg.features import sent2features, sent2labels
 
-# ------------ utilities -------------
 def _read_conll(path: Path):
     sents, sent = [], []
     for line in path.read_text(encoding="utf-8").splitlines():
@@ -24,7 +23,6 @@ def _read_conll(path: Path):
             sent.append((tok, lab))
     return sents
 
-# ------------ CRF -------------------
 def train_crf(cfg: Dict):
     sents = _read_conll(Path(cfg["data"]["train_conll"]))
     model = crf_model.train(
@@ -37,7 +35,6 @@ def train_crf(cfg: Dict):
     (out / "crf.pkl").write_bytes(__import__("pickle").dumps(model))
     return model
 
-# ------------ PhoBERT ---------------
 def train_transformer(cfg: Dict):
     if version.parse(transformers.__version__) < version.parse("4.41.0"):
         raise RuntimeError(
@@ -51,7 +48,7 @@ def train_transformer(cfg: Dict):
         # the tokenizer API which expects strings or lists of strings.
         texts = [str(t) for t in batch["free_text"]]
         enc = tk(texts, truncation=True)
-        enc["labels"] = [[0]*len(x) for x in enc["input_ids"]]  # dummy (B/I cần gắn nhãn thực nếu muốn)
+        enc["labels"] = [[0] * len(x) for x in enc["input_ids"]]
         return enc
 
     train_df = pd.read_csv(cfg["data"]["train_path"])


### PR DESCRIPTION
## Summary
- clean CLI utilities by dropping commented notes
- remove placeholder comments in classification CLI
- strip helper notes from dataset and trainer modules
- drop alias comment in regex baseline

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6879294f3a5883289ef020a1cd0f17ea